### PR TITLE
Pass message headers to job block

### DIFF
--- a/lib/minion.rb
+++ b/lib/minion.rb
@@ -57,7 +57,7 @@ module Minion
 
 					args = decode_json(m)
 
-					result = yield(args)
+					result = yield(args,h)
 
 					next_job(args, result)
 				rescue Object => e

--- a/lib/minion.rb
+++ b/lib/minion.rb
@@ -11,7 +11,7 @@ module Minion
 		@@config_url = url
 	end
 
-	def enqueue(jobs, data = {})
+	def enqueue(jobs, data = {}, headers = {})
 		raise "cannot enqueue a nil job" if jobs.nil?
 		raise "cannot enqueue an empty job" if jobs.empty?
 
@@ -25,7 +25,7 @@ module Minion
 
 		encoded = JSON.dump(data)
 		log "send: #{queue}:#{encoded}"
-		bunny.queue(queue, :durable => true, :auto_delete => false).publish(encoded)
+		bunny.queue(queue, :durable => true, :auto_delete => false).publish(encoded, headers)
 	end
 
 	def log(msg)


### PR DESCRIPTION
For us, it would be incredibly useful to have access to the message headers from the block passed to `job`.

Passing the headers as the second argument shouldn't break existing code unless a lambda (which checks arity) is passed to `job` instead of a block. 
