### PR TITLE
Please accept this simple, two-character edit. The deprecation warning is annoying. Thanks. ~Day

### DIFF
--- a/lib/minion.rb
+++ b/lib/minion.rb
@@ -1,6 +1,6 @@
 require 'uri'
 require 'json' unless defined? ActiveSupport::JSON
-require 'mq'
+require 'amqp'
 require 'bunny'
 require 'minion/handler'
 


### PR DESCRIPTION
This is to accommodate the deprecation of 'mq' as a means of referring to AMQP, and to avoid the verbose deprecation warning.
