### PR TITLE
Fix typo in chaining example in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -63,7 +63,7 @@ queues when you enqueue.
   end
 
   job "eat.sandwich" do |args|
-    puts "I have #{args["type"]} sandwich for #{args["me"]}"
+    puts "I have #{args["type"]} sandwich for #{args["for"]}"
   end
 
 == Conditional Processing


### PR DESCRIPTION
Just a nitpicky little PR here... The "Chaining multiple steps" example in the readme had a typo in the code example.
